### PR TITLE
Added an authentication check endpoint. 

### DIFF
--- a/Ousse/WebService/Middleware/AuthCheckService.class.php
+++ b/Ousse/WebService/Middleware/AuthCheckService.class.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: amaury
+ * Date: 15/02/16
+ * Time: 16:33
+ */
+
+namespace Ousse\WebService\Middleware;
+
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class AuthCheckService extends Service
+{
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $args)
+    {
+        // If the user reached this point he is authenticated, as the middleware catches the
+        // requests unauthenticated or authenticated without a post access.
+        // This may evolve if the permissions become more complex.
+
+        $user = (isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER']: "");
+
+        $response->getBody()->write(json_encode([
+            'username' => $user,
+            'permissions' => [
+                'can_post' => true
+            ]
+        ]));
+
+        $response = $response->withHeader('Content-type', 'application/json');
+
+        return $response;
+    }
+}

--- a/Ousse/WebService/Middleware/AuthService.class.php
+++ b/Ousse/WebService/Middleware/AuthService.class.php
@@ -53,5 +53,5 @@ class AuthService extends EntiteService
         }
 
         return $response;
-        }
+    }
 }

--- a/index.php
+++ b/index.php
@@ -20,6 +20,7 @@ $app = new Slim\App($container);
 $app->add(new \Ousse\WebService\Middleware\AuthService($entityManager));
 
 $app->get('/ping', new \Ousse\WebService\Middleware\PingService());
+$app->post('/check_auth', new Ousse\WebService\Middleware\AuthCheckService());
 
 $app->get('/parametres', new \Ousse\WebService\Middleware\MapParamsService($map));
 


### PR DESCRIPTION
Added an authentication check endpoint, listing the permissions and the username of the current user.

Endpoint:

```
POST /check_auth
```

Returns currently:

``` json
{"username":"amaury","permissions":{"can_post":true}}
```

...if the user is logged in; a 401 error else.

Used [in the Bukkit side](https://github.com/zDevelopers/zBanque-Bukkit/blob/master/src%2Fmain%2Fjava%2Ffr%2Fzcraft%2Fzbanque%2Fnetwork%2Fpackets%2FPacketPlayOutAuthCheck.java) to check when the server starts if the given credentials are valid (avoiding to wait for a request to get an error).
